### PR TITLE
Use stable docker image base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21
 
 WORKDIR /app
 


### PR DESCRIPTION
The openjdk docker image is deprecated, replace it with one that is stable and supported.

See deprecation notice at the top here: https://hub.docker.com/_/openjdk

Of the suggested replacements, I think the Eclipse Temurin build is the most suitable, but any of the others should be fine too.

I think it is important that tutorials steer people to the right choice for things like this. Since it is counter intuitive that the `openjdk` image is deprecated and shouldn't be used. Because that of course looks like a safe choice.

Saw this in the JetBrains blog: https://blog.jetbrains.com/kotlin/2025/12/kubernetes-made-simple-a-guide-for-jvm-developers/

Ideally if you have contacts there, they update their shown example too.